### PR TITLE
Add like toggle interaction for posts

### DIFF
--- a/index.css
+++ b/index.css
@@ -83,6 +83,10 @@ html, body {
     line-height: 1;
 }
 
+.liked {
+    color: red;
+  }
+
 /* Shared utilities */
 .post-header, .post-actions {
     gap: 12px;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,58 @@
 import { posts } from "./data.js"
 
+document.addEventListener("click", function(e) {
+    if (e.target.dataset.like) {
+        handleLikeClick(e.target.dataset.like)
+    }
+})
+
+function handleLikeClick(postId) {
+    const targetPostObj = posts.filter(function(post) {
+        return post.uuid === postId
+    })[0]
+
+    if (targetPostObj.isLiked) {
+        targetPostObj.likes--
+    }
+    else {
+        targetPostObj.likes++
+    }
+    
+    targetPostObj.isLiked = !targetPostObj.isLiked
+
+    // renderPosts()
+    const postElement = document.querySelector(`[data-post-id="${postId}"]`)
+    if (!postElement) return
+
+    const likesEl = postElement.querySelector(".likes-count")
+    if (likesEl) {
+        likesEl.textContent = `${targetPostObj.likes} likes`
+    }
+
+    const heartIcon = postElement.querySelector("[data-like]")
+    if (heartIcon) {
+        if (targetPostObj.isLiked) {
+            heartIcon.classList.remove("fa-regular")
+            heartIcon.classList.add("fa-solid", "liked")
+        } else {
+            heartIcon.classList.remove("fa-solid", "liked")
+            heartIcon.classList.add("fa-regular")
+        }
+    }
+}
+
 function renderPost(post) {
+
+    let likeIconClass = ''
+    let likeStateClass = 'fa-regular'
+
+    if (post.isLiked) {
+        likeIconClass = 'liked'
+        likeStateClass = 'fa-solid'
+    }
+
     return `
-        <article class="post">
+        <article class="post" data-post-id="${post.uuid}">
                 <header class="post-header">
                     <img class="avatar" alt="user avatar" src="${post.avatar}">
                     <div class="user-info">
@@ -16,19 +66,21 @@ function renderPost(post) {
                 </figure>
 
                 <section class="post-actions">
-                    <button class="like-button" data-like="${post.id}">
-                        <i class="fa-regular fa-heart"></i>
+                    <button class="like-button">
+                        <i class="${likeStateClass} fa-heart ${likeIconClass}" data-like="${post.uuid}"></i>
                     </button>
-                    <button class="comment-button" data-comment="${post.id}">
-                        <i class="fa-regular fa-comment"></i>
+                    <button class="comment-button">
+                        <i class="fa-regular fa-comment" data-comment="${post.uuid}"></i>
                     </button>
-                    <button class="dm-button" data-share="${post.id}">
-                        <i class="fa-regular fa-paper-plane"></i>
+                    <button class="dm-button">
+                        <i class="fa-regular fa-paper-plane" data-share="${post.uuid}"></i>
                     </button>
                 </section>
 
                 <section class="post-likes">
                     <p class="likes-count">${post.likes} likes</p>
+                </section>
+
                 <section class="post-caption">
                     <p><span class="user-handle">${post.username}</span> <span class="post-caption-text">${post.comment}</span></p>
                 </section>
@@ -38,10 +90,15 @@ function renderPost(post) {
 
 const postsContainer = document.querySelector(".app-main");
 
-let allPosts = "";
+function renderPosts() {
 
-for (let post of posts) {
-    allPosts += renderPost(post);
+    let allPosts = "";
+
+    for (let post of posts) {
+        allPosts += renderPost(post);
+    }
+
+    postsContainer.innerHTML = allPosts;
 }
 
-postsContainer.innerHTML = allPosts;
+renderPosts()


### PR DESCRIPTION
This update implements the Like button interaction for all posts in the feed.
Users can now toggle likes on individual posts, and the UI updates immediately without re-rendering the entire feed.

**Changes**

- Added event delegation for detecting data-like clicks
- Implemented handleLikeClick() to:
-- identify the correct post using its UUID
-- toggle the isLiked state
-- increment or decrement the likes count
- Switched the heart icon between fa-regular (outline) and fa-solid (filled) when liked
- Applied the .liked class to show the red heart style
- Updated the DOM in place for the clicked post:
-- updates the likes text
-- updates the heart icon classes
- Avoided full re-render to preserve scroll position